### PR TITLE
Remove explicit dependency on jdk8 stdlib

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,6 @@ repositories {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
     testImplementation(libs.bundles.junit)
     testImplementation(libs.hamkrest)
     testImplementation(libs.hamcrest)


### PR DESCRIPTION
This should have been removed with the move to JDK 17